### PR TITLE
[DEV] hotfix #6 fixing release pipeline's gitversion version and main tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,24 +33,29 @@ jobs:
         distribution: 'adopt'
         cache: 'maven'
 
-    # Step 3: Tag immediately if the branch is `main`
-    - name: Tag main branch immediately
-      if: github.ref == 'refs/heads/main'
-      run: |
-        git config user.name "GitHub Actions"
-        git config user.email "actions@github.com"
-        git tag -a ${{ steps.gitversion.outputs.majorMinorPatch }} -m "Stable Release ${{ steps.gitversion.outputs.majorMinorPatch }}"
-        git push origin ${{ steps.gitversion.outputs.majorMinorPatch }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # Step 4: Install GitVersion
+    # Step 3: Install GitVersion
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.0.3
       with:
         versionSpec: '6.0.5'
 
-    # Step 5: Run GitVersion to determine the version
+    # Step 4: Run GitVersion to determine the majorMinorPatch, then tag if the branch is `main`
+    - name: Get majorMinorPatch version with GitVersion before tagging on main
+      if: github.ref == 'refs/heads/main'
+      id: gitversion_main
+      uses: gittools/actions/gitversion/execute@v3.0.3
+    
+    - name: Tag main branch immediately
+      if: github.ref == 'refs/heads/main'
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        git tag -a ${{ steps.gitversion_main.outputs.majorMinorPatch }} -m "Stable Release ${{ steps.gitversion_main.outputs.majorMinorPatch }}"
+        git push origin ${{ steps.gitversion_main.outputs.majorMinorPatch }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Step 5: Run GitVersion to determine version (updated after tagging if first got version with main from Step 4)
     - name: Determine version with GitVersion
       id: gitversion
       uses: gittools/actions/gitversion/execute@v3.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.0.3
       with:
-        versionSpec: '6.x'
+        versionSpec: '6.0.5'
 
     # Step 5: Run GitVersion to determine the version
     - name: Determine version with GitVersion


### PR DESCRIPTION
- `versonSpec` of `gittools/actions/gitversion` fixed to 6.0.5
- Running `gitversion_main` task before tagging main branch with majorMinorPatch (in addition to `gitversion` task that runs all the time)

closes #6 