### PR TITLE
[DEV] Added SPDX-compliant MIT license header to all code files

### DIFF
--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactory.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactory.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.java_websocket.client.WebSocketClient;

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/MessageHandler.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/MessageHandler.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.java_websocket.client.WebSocketClient;

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketClientFactory.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketClientFactory.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.java_websocket.client.WebSocketClient;

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.apache.kafka.common.config.ConfigDef;

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTask.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTask.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.apache.kafka.connect.data.Schema;

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactoryTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactoryTest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketConnectorIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketConnectorIT.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.junit.jupiter.api.*;

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorTest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTaskTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTaskTest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.apache.kafka.connect.source.SourceRecord;

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/util/MockWebSocketServer.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/util/MockWebSocketServer.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket.util;
 
 import org.java_websocket.server.WebSocketServer;


### PR DESCRIPTION
#  📚 Added SPDX-compliant MIT license header to all code files

This PR added SPDX-License-Identifier and Copyright to all source code files in the repo.

---

## 🧩 Key Changes
### 🗒️Documentation:
- Added `SPDX-License-Identifier: MIT` and `Copyright (c) 2025 Konstantin Charkseliani` to all source code files

---