### PR TITLE
[DEV] feature #11 added application-level ping and pong handling

### DIFF
--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactory.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactory.java
@@ -7,6 +7,9 @@ import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 
 import java.net.URI;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.regex.Pattern;
 
 /**
  * Implementation of {@link WebSocketClientFactory} using the Java-WebSocket library.
@@ -18,34 +21,85 @@ import java.net.URI;
 public class DefaultWebSocketClientFactory implements WebSocketClientFactory {
 
     /**
-     * Creates a {@link WebSocketClient} instance that connects to the specified URI and handles messages using the provided handler.
+     * Creates a {@link WebSocketClient} instance that connects to the specified URI,
+     * optionally sends a subscription message upon connection, periodically sends ping messages,
+     * filters out pong responses based on a pattern and delegates message handling to the provided {@link MessageHandler}.
      *
      * @param uri the WebSocket server URI to connect to
      * @param subscriptionMessage optional message to send immediately after connection (e.g., subscription payload)
-     * @param messageHandler callback to process incoming WebSocket messages
+     * @param pingMessage optional application-level ping message to send periodically (e.g., {"method":"ping"}); empty string disables ping
+     * @param pingIntervalMs interval in milliseconds between sending ping messages; ignored if pingMessage is empty
+     * @param pongPattern optional regular expression pattern used to detect pong responses; matching messages are not forwarded to the handler
+     * @param messageHandler callback to process incoming WebSocket messages (when they don't match pong pattern if any)
      * @return a configured {@link WebSocketClient} instance
      */
     @Override
-    public WebSocketClient createClient(URI uri, String subscriptionMessage, MessageHandler messageHandler) {
+    public WebSocketClient createClient(
+        URI uri,
+        String subscriptionMessage,
+        String pingMessage,
+        int pingIntervalMs,
+        String pongPattern,
+        MessageHandler messageHandler
+    ) {
         return new WebSocketClient(uri) {
+
+            /** Timer used to schedule periodic sending of application-level ping messages */
+            private Timer pingTimer;
+
+            /** Compiled regular expression used to identify application-level pong messages */
+            private final Pattern pongRegex = (pongPattern != null && !pongPattern.isEmpty())
+                ? Pattern.compile(pongPattern)
+                : null;
 
             @Override
             public void onOpen(ServerHandshake handshake) {
                 System.out.println("Connected to WebSocket");
+
                 if (subscriptionMessage != null && !subscriptionMessage.isEmpty()) {
                     send(subscriptionMessage); // Send the subscription message
                     System.out.println("Sent the initial subscription message to the websocket");
+                }
+
+                // If ping message was provided, schedule a background timer task to
+                // periodically send the application-level ping message at fixed intervals
+                // to keep the WebSocket connection alive
+                if (pingMessage != null && !pingMessage.isEmpty() && pingIntervalMs > 0) {
+                    pingTimer = new Timer(true);
+                    pingTimer.scheduleAtFixedRate(new TimerTask() {
+                        @Override
+                        public void run() {
+                            // Only send the ping if the connection is still open
+                            if (isOpen()) {
+                                send(pingMessage);
+                                System.out.println("Sent ping message: " + pingMessage);
+                            }
+                        }
+                    }, 0, pingIntervalMs);
                 }
             }
     
             @Override
             public void onMessage(String message) {
-                messageHandler.handle(message); // Use the lambda to handle the message
+
+                // Skip pong messages if they match the configured pattern
+                if (pingMessage != null && 
+                    !pingMessage.isEmpty() && 
+                    pongRegex != null && 
+                    pongRegex.matcher(message).find()
+                    ) {
+                    System.out.println("Received pong message: " + message);
+                    return;
+                }
+
+                // Use the provided lambda to handle the incoming message
+                messageHandler.handle(message);
             }
     
             @Override
             public void onClose(int code, String reason, boolean remote) {
                 System.out.println("WebSocket closed: " + reason);
+                if (pingTimer != null) pingTimer.cancel();
             }
     
             @Override

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketClientFactory.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketClientFactory.java
@@ -14,12 +14,24 @@ import java.net.URI;
  */
 public interface WebSocketClientFactory {
     /**
-     * Creates a {@link WebSocketClient} instance that connects to the specified URI and handles messages using the provided handler.
+     * Creates a {@link WebSocketClient} instance that connects to the specified URI,
+     * optionally sends a subscription message upon connection, periodically sends ping messages,
+     * filters out pong responses based on a pattern and delegates message handling to the provided {@link MessageHandler}.
      *
      * @param uri the WebSocket server URI to connect to
      * @param subscriptionMessage optional message to send immediately after connection (e.g., subscription payload)
-     * @param messageHandler callback to process incoming WebSocket messages
+     * @param pingMessage optional application-level ping message to send periodically (e.g., {"method":"ping"}); empty string disables ping
+     * @param pingIntervalMs interval in milliseconds between sending ping messages; ignored if pingMessage is empty
+     * @param pongPattern optional regular expression pattern used to detect pong responses; matching messages are not forwarded to the handler
+     * @param messageHandler callback to process incoming WebSocket messages (when they don't match pong pattern if any)
      * @return a configured {@link WebSocketClient} instance
      */
-    WebSocketClient createClient(URI uri, String subscriptionMessage, MessageHandler messageHandler);
+    WebSocketClient createClient(
+        URI uri,
+        String subscriptionMessage,
+        String pingMessage,
+        int pingIntervalMs,
+        String pongPattern,
+        MessageHandler messageHandler
+    );
 }

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
@@ -44,9 +44,31 @@ public class WebSocketSourceConnector extends SourceConnector {
         .define(
             "websocket.subscription.message", 
             ConfigDef.Type.STRING, 
-            "", // Default to an empty string if not provided
+            "",
             ConfigDef.Importance.LOW, 
             "Optional subscription message to send after connecting to the WebSocket."
+        )
+        .define(
+            "websocket.ping.message",
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            "Optional ping message to send periodically to keep the WebSocket connection alive."
+        )
+        .define(
+            "websocket.ping.interval.ms",
+            ConfigDef.Type.INT,
+            20000,
+            ConfigDef.Importance.LOW,
+            "Interval in milliseconds between each ping message."
+        )
+        .define(
+            "websocket.pong.pattern",
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            "Regex pattern to detect pong responses in incoming WebSocket messages. " +
+            "If not provided, pong responses will be sent alongside other messages."
         );
     
     // Static initializer to load the config.properties file at class loading time

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
@@ -17,7 +17,15 @@ import java.util.Properties;
 /**
  * A Kafka Connect {@link SourceConnector} implementation that streams messages from a WebSocket server into a Kafka topic.
  * 
- * This connector supports an optional subscription message that can be sent after establishing a WebSocket connection.
+ * This connector supports:
+ * <ul>
+ *   <li>An optional subscription message sent immediately after establishing the WebSocket connection</li>
+ *   <li>Periodic sending of configurable application-level ping messages to keep the connection alive</li>
+ *   <li>Filtering out of application-level pong messages using a configurable regex pattern</li>
+ * </ul>
+ * 
+ * Incoming WebSocket messages (excluding matched pong responses) are forwarded to Kafka as
+ * {@link org.apache.kafka.connect.source.SourceRecord} entries.
  */
 public class WebSocketSourceConnector extends SourceConnector {
 

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
@@ -34,50 +34,6 @@ public class WebSocketSourceConnector extends SourceConnector {
 
      /** Properties loaded from the internal config.properties file (e.g., for version information). */
     private static final Properties properties = new Properties();
-
-    /** Defines the configuration options supported by this connector. */
-    private static final ConfigDef CONFIG_DEF = new ConfigDef()
-        .define(
-            "websocket.url", 
-            ConfigDef.Type.STRING, 
-            ConfigDef.Importance.HIGH, 
-            "The WebSocket URL to connect to."
-        )
-        .define(
-            "topic", 
-            ConfigDef.Type.STRING, 
-            ConfigDef.Importance.HIGH, 
-            "The Kafka topic where WebSocket messages will be published."
-        )
-        .define(
-            "websocket.subscription.message", 
-            ConfigDef.Type.STRING, 
-            "",
-            ConfigDef.Importance.LOW, 
-            "Optional subscription message to send after connecting to the WebSocket."
-        )
-        .define(
-            "websocket.ping.message",
-            ConfigDef.Type.STRING,
-            "",
-            ConfigDef.Importance.LOW,
-            "Optional ping message to send periodically to keep the WebSocket connection alive."
-        )
-        .define(
-            "websocket.ping.interval.ms",
-            ConfigDef.Type.INT,
-            20000,
-            ConfigDef.Importance.LOW,
-            "Interval in milliseconds between each ping message."
-        )
-        .define(
-            "websocket.pong.pattern",
-            ConfigDef.Type.STRING,
-            "",
-            ConfigDef.Importance.LOW,
-            "Regex pattern to detect pong responses in incoming WebSocket messages. " +
-            "If not provided, pong responses will be sent alongside other messages."
-        );
     
     // Static initializer to load the config.properties file at class loading time
     static {
@@ -112,9 +68,12 @@ public class WebSocketSourceConnector extends SourceConnector {
      */
     @Override
     public void start(Map<String, String> props) {
+        
         // Retrieve essential configurations
-        String websocketUrl = props.get("websocket.url");
-        String topic = props.get("topic");
+        WebSocketSourceConnectorConfig config = new WebSocketSourceConnectorConfig(props);
+
+        String websocketUrl = config.getString("websocket.url");
+        String topic = config.getString("topic");
         
         // Validate required configurations
         if (websocketUrl == null || websocketUrl.isEmpty()) {
@@ -170,6 +129,6 @@ public class WebSocketSourceConnector extends SourceConnector {
      * @return the configuration definition
      */
     public ConfigDef config() {
-        return CONFIG_DEF;
+        return WebSocketSourceConnectorConfig.CONFIG_DEF;
     }
 }

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnector.java
@@ -68,20 +68,9 @@ public class WebSocketSourceConnector extends SourceConnector {
      */
     @Override
     public void start(Map<String, String> props) {
-        
-        // Retrieve essential configurations
-        WebSocketSourceConnectorConfig config = new WebSocketSourceConnectorConfig(props);
 
-        String websocketUrl = config.getString("websocket.url");
-        String topic = config.getString("topic");
-        
-        // Validate required configurations
-        if (websocketUrl == null || websocketUrl.isEmpty()) {
-            throw new IllegalArgumentException("Missing required configuration: websocket.url");
-        }
-        if (topic == null || topic.isEmpty()) {
-            throw new IllegalArgumentException("Missing required configuration: topic");
-        }
+        // Validate essential configurations
+        new WebSocketSourceConnectorConfig(props);
 
         // Save the connector's configuration properties
         this.configProperties = props;

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorConfig.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorConfig.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.connect.websocket;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -5,6 +8,23 @@ import org.apache.kafka.common.config.ConfigDef;
 
 import java.util.Map;
 
+/**
+ * Configuration class for the {@link WebSocketSourceConnector}.
+ *
+ * <p>This class defines and validates all configuration options for the connector.
+ * It extends {@link AbstractConfig} to provide access to typed values with defaults
+ * and validation checks.</p>
+ *
+ * <p>Supported configuration parameters:</p>
+ * <ul>
+ *   <li><b>websocket.url</b> (String, required): The WebSocket endpoint to connect to</li>
+ *   <li><b>topic</b> (String, required): The Kafka topic to publish incoming WebSocket messages</li>
+ *   <li><b>websocket.subscription.message</b> (String, optional): Optional subscription message sent immediately after connection</li>
+ *   <li><b>websocket.ping.message</b> (String, optional): Optional ping message sent periodically to keep the connection alive</li>
+ *   <li><b>websocket.ping.interval.ms</b> (int, optional, default: 20000): Interval between pings in milliseconds</li>
+ *   <li><b>websocket.pong.pattern</b> (String, optional): Regex pattern used to filter out pong responses from the WebSocket stream</li>
+ * </ul>
+ */
 public class WebSocketSourceConnectorConfig extends AbstractConfig {
 
     /** Defines the configuration options supported by this connector. */
@@ -51,6 +71,11 @@ public class WebSocketSourceConnectorConfig extends AbstractConfig {
             "If not provided, pong responses will be sent alongside other messages."
         );
 
+    /**
+     * Constructs a new {@link WebSocketSourceConnectorConfig} using the given properties.
+     *
+     * @param props the raw configuration properties provided by the Kafka Connect framework
+     */
     public WebSocketSourceConnectorConfig(Map<String, String> props) {
         super(CONFIG_DEF, props);
     }

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorConfig.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorConfig.java
@@ -1,0 +1,57 @@
+package com.kcharkseliani.kafka.connect.websocket;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+
+public class WebSocketSourceConnectorConfig extends AbstractConfig {
+
+    /** Defines the configuration options supported by this connector. */
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+        .define(
+            "websocket.url", 
+            ConfigDef.Type.STRING, 
+            ConfigDef.Importance.HIGH, 
+            "The WebSocket URL to connect to."
+        )
+        .define(
+            "topic", 
+            ConfigDef.Type.STRING, 
+            ConfigDef.Importance.HIGH, 
+            "The Kafka topic where WebSocket messages will be published."
+        )
+        .define(
+            "websocket.subscription.message", 
+            ConfigDef.Type.STRING, 
+            "",
+            ConfigDef.Importance.LOW, 
+            "Optional subscription message to send after connecting to the WebSocket."
+        )
+        .define(
+            "websocket.ping.message",
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            "Optional ping message to send periodically to keep the WebSocket connection alive."
+        )
+        .define(
+            "websocket.ping.interval.ms",
+            ConfigDef.Type.INT,
+            20000,
+            ConfigDef.Importance.LOW,
+            "Interval in milliseconds between each ping message."
+        )
+        .define(
+            "websocket.pong.pattern",
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            "Regex pattern to detect pong responses in incoming WebSocket messages. " +
+            "If not provided, pong responses will be sent alongside other messages."
+        );
+
+    public WebSocketSourceConnectorConfig(Map<String, String> props) {
+        super(CONFIG_DEF, props);
+    }
+}

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTask.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTask.java
@@ -17,8 +17,15 @@ import java.io.InputStream;
 import java.util.Properties;
 
 /**
- * A Kafka Connect {@link SourceTask} implementation that receives messages from a WebSocket server
- * and produces them to a Kafka topic as {@link SourceRecord} entries.
+ * A Kafka Connect {@link SourceTask} implementation that receives messages from a WebSocket server and
+ * produces those that do not match the pong pattern to a Kafka topic as {@link SourceRecord} entries.
+ * 
+ * It supports:
+ * <ul>
+ *   <li>An optional subscription message sent immediately after establishing the WebSocket connection</li>
+ *   <li>Periodic sending of configurable application-level ping messages to keep the connection alive</li>
+ *   <li>Filtering out of application-level pong messages using a configurable regex pattern</li>
+ * </ul>
  */
 public class WebSocketSourceTask extends SourceTask {
 

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTask.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTask.java
@@ -78,13 +78,16 @@ public class WebSocketSourceTask extends SourceTask {
      */
     @Override
     public void start(Map<String, String> props) {
-        kafkaTopic = props.get("topic");
+        
+        WebSocketSourceConnectorConfig config = new WebSocketSourceConnectorConfig(props);
 
-        String websocketUrl = props.get("websocket.url");
-        String subscriptionMessage = props.get("websocket.subscription.message");
-        String pingMessage = props.get("websocket.ping.message");
-        int pingIntervalMs = Integer.parseInt(props.get("websocket.ping.interval.ms"));
-        String pongPattern = props.get("websocket.pong.pattern");
+        kafkaTopic = config.getString("topic");
+
+        String websocketUrl = config.getString("websocket.url");
+        String subscriptionMessage = config.getString("websocket.subscription.message");
+        String pingMessage = config.getString("websocket.ping.message");
+        int pingIntervalMs = config.getInt("websocket.ping.interval.ms");
+        String pongPattern = config.getString("websocket.pong.pattern");
 
         // Pass the subscription message to the client
         client = clientFactory.createClient(

--- a/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTask.java
+++ b/src/main/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTask.java
@@ -72,15 +72,31 @@ public class WebSocketSourceTask extends SourceTask {
     @Override
     public void start(Map<String, String> props) {
         kafkaTopic = props.get("topic");
-        String subscriptionMessage = props.get("websocket.subscription.message"); // Retrieve subscription message
+
+        String websocketUrl = props.get("websocket.url");
+        String subscriptionMessage = props.get("websocket.subscription.message");
+        String pingMessage = props.get("websocket.ping.message");
+        int pingIntervalMs = Integer.parseInt(props.get("websocket.ping.interval.ms"));
+        String pongPattern = props.get("websocket.pong.pattern");
 
         // Pass the subscription message to the client
-        client = clientFactory.createClient(URI.create(props.get("websocket.url")), subscriptionMessage, message -> {
-            SourceRecord record = new SourceRecord(
-                null, null, kafkaTopic, Schema.STRING_SCHEMA, message
-            );
-            recordsQueue.add(record);
-        });       
+        client = clientFactory.createClient(
+            URI.create(websocketUrl),
+            subscriptionMessage,
+            pingMessage,
+            pingIntervalMs,
+            pongPattern,
+            message -> {
+                SourceRecord record = new SourceRecord(
+                    null, 
+                    null, 
+                    kafkaTopic, 
+                    Schema.STRING_SCHEMA, 
+                    message
+                );
+                recordsQueue.add(record);
+            }
+        );      
 
         client.connect();
     }

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactoryTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactoryTest.java
@@ -39,16 +39,24 @@ class DefaultWebSocketClientFactoryTest {
         // Arrange
         URI testUri = new URI("ws://localhost:8080");
         String subscriptionMessage = "test_subscription_message";
+        String pingMessage = "{\"message\":\"ping\"}";
+        int pingIntervalMs = 20000;
+        String pongPattern = "\"message\"\\s*:\\s*\"pong\"";
         MessageHandler messageHandler = message -> {
             // Handle the message
         };
 
         // Act
-        WebSocketClient client = clientFactory.createClient(testUri, subscriptionMessage, messageHandler);
+        WebSocketClient client = clientFactory.createClient(
+            testUri, 
+            subscriptionMessage, 
+            pingMessage,
+            pingIntervalMs,
+            pongPattern,
+            messageHandler);
 
         // Assert
         assertNotNull(client, "Expected WebSocketClient to be created, but it is null instead.");
-        // Use reflection to access the private 'uri' field of the WebSocketClient
         assertEquals(testUri, client.getURI(), "WebSocketClient URI should match the provided URI.");
     }   
 }

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactoryTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/DefaultWebSocketClientFactoryTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.java_websocket.client.WebSocketClient;
 
 import java.net.URI;
+import java.util.regex.Pattern;
+import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,12 +32,12 @@ class DefaultWebSocketClientFactoryTest {
 
     /**
      * Tests that {@link DefaultWebSocketClientFactory#createClient(URI, String, MessageHandler)}
-     * returns a {@link WebSocketClient} initialized with the provided URI.
+     * returns a {@link WebSocketClient} initialized with the provided URI and a valid pong pattern Regex.
      *
      * @throws Exception if URI creation or WebSocket client setup fails
      */
     @Test
-    void testCreateClient_WithValidParameters_ShouldReturnWebSocketClientWithUri() throws Exception {
+    void testCreateClient_WithValidParameters_ShouldReturnWebSocketClientWithUriAndPattern() throws Exception {
         // Arrange
         URI testUri = new URI("ws://localhost:8080");
         String subscriptionMessage = "test_subscription_message";
@@ -58,6 +60,11 @@ class DefaultWebSocketClientFactoryTest {
         // Assert
         assertNotNull(client, "Expected WebSocketClient to be created, but it is null instead.");
         assertEquals(testUri, client.getURI(), "WebSocketClient URI should match the provided URI.");
+
+        Field pongField = client.getClass().getDeclaredField("pongRegex");
+        pongField.setAccessible(true);
+        Pattern actualPongRegex = (Pattern) pongField.get(client);
+        assertNotNull(actualPongRegex, "Expected pongRegex to be initialized.");
     }   
 }
 

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketConnectorIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketConnectorIT.java
@@ -14,6 +14,7 @@ import com.kcharkseliani.kafka.connect.websocket.util.MockWebSocketServer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.kafka.clients.admin.*;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -30,6 +31,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import org.testcontainers.containers.Network;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Integration tests for the WebSocket Kafka Source Connector 
@@ -129,7 +132,7 @@ public class WebSocketConnectorIT {
      */
     @Test
     void testConnectorDeployment_ShouldSucceed() throws Exception {
-        deployWebSocketConnector();
+        deployWebSocketConnector(false);
     }   
 
     /**
@@ -140,7 +143,7 @@ public class WebSocketConnectorIT {
      */
     @Test
     void testConnectorDeployment_ShouldEstablishConnectionToServer() throws Exception {
-        deployWebSocketConnector();
+        deployWebSocketConnector(false);
 
         // Wait up to 5 seconds for connector to establish WebSocket connection
         boolean connected = waitForWebSocketConnection(5_000);
@@ -157,7 +160,7 @@ public class WebSocketConnectorIT {
     @Test
     void testConnectorDeployment_ShouldSendSubscriptionMessageToServer() throws Exception {
         // Step 1: Deploy the WebSocket Kafka Connector
-        deployWebSocketConnector();
+        deployWebSocketConnector(false);
 
         // Step 2: Wait for connector to establish WebSocket connection
         boolean connected = waitForWebSocketConnection(5_000);
@@ -185,7 +188,7 @@ public class WebSocketConnectorIT {
     @Test
     void testWebSocketMessage_ShouldBePublishedToKafkaTopic() throws Exception {
         // Step 1: Deploy the WebSocket Kafka Connector
-        deployWebSocketConnector();
+        deployWebSocketConnector(false);
 
         // Step 2: Wait for the connector to establish a WebSocket connection
         boolean connected = waitForWebSocketConnection(5_000);
@@ -236,6 +239,95 @@ public class WebSocketConnectorIT {
     }
 
     /**
+     * Full end-to-end test to verify that a WebSocket app-level ping message
+     * is sent to the server and returned pong is ignored by the connector.
+     *
+     * @throws Exception if message publishing or validation fails
+     */
+    @Test
+    void testWebSocketPing_ShouldSendAndIgnorePong() throws Exception {
+
+        // Test and ping messages expected to be sent to or received from the websocket server
+        String expectedTestMessage = "{\"data\": \"test\"}";
+        String expectedPingMessage = "{\"message\": \"ping\"}";
+        String expectedPongMessage = "{\"message\": \"pong\"}";
+
+        // Step 1: Deploy the WebSocket Kafka Connector
+        deployWebSocketConnector(true);
+
+        // Step 2: Wait for the connector to establish a WebSocket connection
+        boolean connected = waitForWebSocketConnection(5_000);
+        assertTrue(connected, "Connector should establish a WebSocket connection to the mock server");
+
+        // Step 3: Send a test WebSocket message and pong through the mock WebSocket server
+        websocketServer.broadcast(expectedTestMessage);
+
+        websocketServer.broadcast(expectedPongMessage);
+
+        // Step 4: Configure Kafka consumer properties
+        Properties consumerProps = new Properties();
+        consumerProps.put("bootstrap.servers", kafka.getBootstrapServers()); // Connect to the Kafka container
+        consumerProps.put("group.id", "test-consumer-group"); // Group ID for isolation
+        consumerProps.put("key.deserializer", StringDeserializer.class.getName()); // Key deserializer
+        consumerProps.put("value.deserializer", StringDeserializer.class.getName()); // Value deserializer
+        consumerProps.put("auto.offset.reset", "earliest"); // Make sure we read messages from the beginning
+
+        // Step 5: Create a Kafka consumer to consume from the 'test-topic' topic
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps)) {
+            consumer.subscribe(List.of(TOPIC)); // Subscribe to the topic produced by the connector
+
+            boolean messageReceived = false;
+            long timeoutMillis = 5000; // How long to wait for the message
+            long start = System.currentTimeMillis();
+
+            // Step 6: Poll Kafka for new messages until timeout expires
+            while (System.currentTimeMillis() - start < timeoutMillis) {
+                ConsumerRecords<String, String> records = consumer.poll(java.time.Duration.ofMillis(500)); // poll every 500ms
+
+                for (ConsumerRecord<String, String> record : records) {
+                    String value = record.value();
+                    System.out.println("Received message from Kafka: " + value);
+
+                    if (value.contains(expectedTestMessage)) {
+                        messageReceived = true;
+                    } else if (value.contains(expectedPongMessage)) {
+                        fail("Pong message should have been filtered out and not appear in Kafka.");
+                    }
+                }
+
+                if (messageReceived) {
+                    break; // Stop polling once we found the expected message
+                }
+            }
+
+            // Step 8: Assert that we successfully received the WebSocket message in Kafka
+            assertTrue(messageReceived, "Expected WebSocket message was not found in Kafka topic 'test-topic'.");
+        }
+
+        // Step 6: Retrieve the messages received by the mock server
+        List<String> receivedMessages = websocketServer.getReceivedMessages();
+
+        // Step 7: Verify that a ping message was received
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode expectedJson = objectMapper.readTree(expectedPingMessage);
+
+        // Since message is a JSON need to make sure we compare as JSON
+        // Otherwise extra white spaces are not handled properly
+        boolean subscriptionReceived = receivedMessages.stream()
+            .map(msg -> {
+                try {
+                    return objectMapper.readTree(msg);
+                } catch (Exception e) {
+                    return null;
+                }
+            })
+            .filter(json -> json != null)
+            .anyMatch(json -> json.equals(expectedJson));
+
+        assertTrue(subscriptionReceived, "Expected ping message was not received by the WebSocket server.");
+    }
+
+    /**
      * Stops all containers and the mock WebSocket server after each test.
      *
      * @throws InterruptedException if container shutdown is interrupted
@@ -280,21 +372,34 @@ public class WebSocketConnectorIT {
     /**
      * Deploys the WebSocket source connector to the running Kafka Connect instance.
      *
+     * @param withPing if true, adds ping-related configuration to keep the WebSocket connection alive
      * @throws Exception if the HTTP request to deploy the connector fails
      */
-    private void deployWebSocketConnector() throws Exception {
+    private void deployWebSocketConnector(boolean withPing) throws Exception {
         String connectUrl = "http://" + connect.getHost() + ":" + connect.getMappedPort(8083);
 
-        String configJson = "{\n" +
-            "  \"name\": \"websocket-source-connector\",\n" +
-            "  \"config\": {\n" +
-            "    \"connector.class\": \"com.kcharkseliani.kafka.connect.websocket.WebSocketSourceConnector\",\n" +
-            "    \"tasks.max\": \"1\",\n" +
-            "    \"websocket.url\": \"ws://host.testcontainers.internal:" + WEBSOCKET_PORT + "\",\n" +
-            "    \"topic\": \"" + TOPIC + "\",\n" +
-            "    \"websocket.subscription.message\": \"{ \\\"message\\\": \\\"subscribe\\\" }\"\n" +
-            "  }\n" +
-            "}";
+        // Base connector config
+        StringBuilder configBuilder = new StringBuilder();
+        configBuilder.append("{\n")
+            .append("  \"name\": \"websocket-source-connector\",\n")
+            .append("  \"config\": {\n")
+            .append("    \"connector.class\": \"com.kcharkseliani.kafka.connect.websocket.WebSocketSourceConnector\",\n")
+            .append("    \"tasks.max\": \"1\",\n")
+            .append("    \"websocket.url\": \"ws://host.testcontainers.internal:").append(WEBSOCKET_PORT).append("\",\n")
+            .append("    \"topic\": \"").append(TOPIC).append("\",\n")
+            .append("    \"websocket.subscription.message\": \"{ \\\"message\\\": \\\"subscribe\\\" }\"");
+
+        if (withPing) {
+            configBuilder.append(",\n")
+                .append("    \"websocket.ping.message\": \"{ \\\"message\\\": \\\"ping\\\" }\",\n")
+                .append("    \"websocket.ping.interval.ms\": \"4000\",\n")
+                .append("    \"websocket.pong.pattern\": \"\\\"message\\\"\\\\s*:\\\\s*\\\"pong\\\"\"");
+        }
+
+        configBuilder.append("\n  }\n}")
+                    .append("\n");
+
+        String configJson = configBuilder.toString();
 
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
@@ -305,7 +410,7 @@ public class WebSocketConnectorIT {
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(201, response.statusCode(), "Connector creation failed: " + response.body());
-    }   
+    }
 
     /**
      * Waits until the WebSocket server detects at least one client connection

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorTest.java
@@ -33,6 +33,15 @@ class WebSocketSourceConnectorTest {
     /** Subscription message that would be sent when connecting to the WebSocket server. */
     private final String subscriptionMessage = "{\"type\":\"subscribe\"}";
 
+        /** Application-level ping message to be sent periodically to the websocket server */
+    private final String pingMessage = "{\"message\":\"ping\"}";
+
+    /** Frequency with which to send the ping message (ms) */
+    private final int pingIntervalMs = 20000;
+
+    /** Pattern of the pong message to match so that pong messages can be excluded from being published */
+    private final String pongPattern = "\"message\"\\s*:\\s*\"pong\"";
+
     /** Properties loaded from {@code config.properties} for version verification. */
     private Properties properties;
 
@@ -65,6 +74,9 @@ class WebSocketSourceConnectorTest {
         props.put("websocket.url", websocketUrl);
         props.put("topic", kafkaTopic);
         props.put("websocket.subscription.message", subscriptionMessage);
+        props.put("websocket.ping.message", pingMessage);
+        props.put("websocket.ping.interval.ms", String.valueOf(pingIntervalMs));
+        props.put("websocket.pong.pattern", pongPattern);
 
         // Act
         connector.start(props);
@@ -141,6 +153,9 @@ class WebSocketSourceConnectorTest {
         props.put("websocket.url", websocketUrl);
         props.put("topic", kafkaTopic);
         props.put("websocket.subscription.message", subscriptionMessage);
+        props.put("websocket.ping.message", pingMessage);
+        props.put("websocket.ping.interval.ms", String.valueOf(pingIntervalMs));
+        props.put("websocket.pong.pattern", pongPattern);
         
         connector.start(props);
         
@@ -150,13 +165,26 @@ class WebSocketSourceConnectorTest {
         // Assert
         assertEquals(1, taskConfigs.size(), 
             "Expected exactly one task config to be returned, but got " + taskConfigs.size());
+
         Map<String, String> config = taskConfigs.get(0);
+
         assertEquals(websocketUrl, config.get("websocket.url"), 
             "WebSocket URL in task config should match the original value.");
+            
         assertEquals(kafkaTopic, config.get("topic"), 
             "Kafka topic in task config should match the original value.");
+
         assertEquals(subscriptionMessage, config.get("websocket.subscription.message"), 
             "Subscription message in task config should match the original value.");
+
+        assertEquals(pingMessage, config.get("websocket.ping.message"), 
+            "Ping message in task config should match the original value.");
+
+        assertEquals(String.valueOf(pingIntervalMs), config.get("websocket.ping.interval.ms"), 
+            "Ping interval in task config should match the original value.");
+
+        assertEquals(pongPattern, config.get("websocket.pong.pattern"), 
+            "Pong pattern in task config should match the original value.");
     }
 
     /**

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceConnectorTest.java
@@ -107,15 +107,10 @@ class WebSocketSourceConnectorTest {
         props.put("topic", kafkaTopic);
 
         // Act & Assert
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
+        assertThrows(
+            org.apache.kafka.common.config.ConfigException.class,
             () -> connector.start(props),
-            "Expected IllegalArgumentException when 'websocket.url' is missing"
-        );
-        assertEquals(
-            "Missing required configuration: websocket.url",
-            exception.getMessage(),
-            "Exception message should indicate the missing 'websocket.url' property"
+            "Expected org.apache.kafka.common.config.ConfigException when'websocket.url' is missing"
         );
     }
 
@@ -130,15 +125,10 @@ class WebSocketSourceConnectorTest {
         props.put("websocket.url", websocketUrl);
 
         // Act & Assert
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
+        assertThrows(
+            org.apache.kafka.common.config.ConfigException.class,
             () -> connector.start(props),
-            "Expected IllegalArgumentException when 'topic' is missing"
-        );
-        assertEquals(
-            "Missing required configuration: topic",
-            exception.getMessage(),
-            "Exception message should indicate the missing 'topic' property"
+            "Expected org.apache.kafka.common.config.ConfigException when 'topic' is missing"
         );
     }
 

--- a/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTaskTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/connect/websocket/WebSocketSourceTaskTest.java
@@ -48,6 +48,15 @@ public class WebSocketSourceTaskTest {
     /** Subscription message to send after WebSocket connection. */
     private final String subscriptionMessage = "{\"action\": \"subscribe\", \"channel\": \"test-stream\"}";
 
+    /** Application-level ping message to be sent periodically to the websocket server */
+    private final String pingMessage = "{\"message\":\"ping\"}";
+
+    /** Frequency with which to send the ping message (ms) */
+    private final int pingIntervalMs = 20000;
+
+    /** Pattern of the pong message to match so that pong messages can be excluded from being published */
+    private final String pongPattern = "\"message\"\\s*:\\s*\"pong\"";
+
      /** Properties loaded from config.properties, mainly for version testing. */
     private Properties properties;
 
@@ -72,30 +81,45 @@ public class WebSocketSourceTaskTest {
     }
 
     /**
-     * Verifies that when the task starts, it sends a subscription message
+     * Verifies that when the task starts, it passes all configs correctly
      * and connects using the created WebSocket client.
      *
      * @throws Exception if WebSocket connection setup fails
      */
     @Test
-    public void testStart_SendsSubscriptionMessageOnOpen() throws Exception {
+    public void testStart_WithAllValidConfigPassed() throws Exception {
         // Prepare props with topic, websocket URL, and subscription message
         Map<String, String> props = Map.of(
             "topic", kafkaTopic,
             "websocket.url", websocketUrl,
-            "websocket.subscription.message", subscriptionMessage
+            "websocket.subscription.message", subscriptionMessage,
+            "websocket.ping.message", pingMessage,
+            "websocket.ping.interval.ms", String.valueOf(pingIntervalMs),
+            "websocket.pong.pattern", pongPattern
         );
 
         // Set up the factory to return the mock client
         doReturn(mockClient)
-            .when(clientFactory).createClient(any(URI.class), any(String.class), any(MessageHandler.class));
+            .when(clientFactory).createClient(
+                any(URI.class), 
+                any(String.class),
+                any(String.class),
+                any(Integer.class),
+                any(String.class),
+                any(MessageHandler.class));
         
         // Call start with the prepared props
         task.start(props);
 
         // Assert
         // Verify that the clientFactory.createClient method was called with the expected arguments
-        verify(clientFactory).createClient(eq(URI.create(websocketUrl)), eq(subscriptionMessage), any(MessageHandler.class));
+        verify(clientFactory).createClient(
+            eq(URI.create(websocketUrl)), 
+            eq(subscriptionMessage), 
+            eq(pingMessage),
+            eq(pingIntervalMs),
+            eq(pongPattern),
+            any(MessageHandler.class));
         
         // Verify that client.connect() was called
         verify(mockClient).connect();
@@ -113,7 +137,10 @@ public class WebSocketSourceTaskTest {
         Map<String, String> props = Map.of(
             "topic", kafkaTopic,
             "websocket.url", websocketUrl,
-            "websocket.subscription.message", subscriptionMessage
+            "websocket.subscription.message", subscriptionMessage,
+            "websocket.ping.message", "",
+            "websocket.ping.interval.ms", String.valueOf(20000),
+            "websocket.pong.pattern", ""
         );
 
         // Capture the MessageHandler when createClient is called
@@ -121,7 +148,13 @@ public class WebSocketSourceTaskTest {
         
         // Set up the factory to return a mock client and capture the handler
         doReturn(mockClient)
-            .when(clientFactory).createClient(any(URI.class), any(String.class), messageHandlerCaptor.capture());
+            .when(clientFactory).createClient(
+                any(URI.class), 
+                any(String.class), 
+                any(String.class),
+                any(Integer.class),
+                any(String.class),
+                messageHandlerCaptor.capture());
 
         // Start the task
         task.start(props);
@@ -154,11 +187,20 @@ public class WebSocketSourceTaskTest {
         Map<String, String> props = Map.of(
             "topic", kafkaTopic,
             "websocket.url", websocketUrl,
-            "websocket.subscription.message", subscriptionMessage
+            "websocket.subscription.message", subscriptionMessage,
+            "websocket.ping.message", "",
+            "websocket.ping.interval.ms", String.valueOf(20000),
+            "websocket.pong.pattern", ""
         );
         // Prepare the task
         doReturn(mockClient)
-            .when(clientFactory).createClient(any(URI.class), any(String.class), any(MessageHandler.class));
+            .when(clientFactory).createClient(
+                any(URI.class), 
+                any(String.class), 
+                any(String.class),
+                any(Integer.class),
+                any(String.class),
+                any(MessageHandler.class));
 
         task.start(props);
 
@@ -180,11 +222,20 @@ public class WebSocketSourceTaskTest {
         Map<String, String> props = Map.of(
             "topic", kafkaTopic,
             "websocket.url", websocketUrl,
-            "websocket.subscription.message", subscriptionMessage
+            "websocket.subscription.message", subscriptionMessage,
+            "websocket.ping.message", "",
+            "websocket.ping.interval.ms", String.valueOf(20000),
+            "websocket.pong.pattern", ""
         );
         // Prepare the task
         doReturn(mockClient)
-            .when(clientFactory).createClient(any(URI.class), any(String.class), any(MessageHandler.class));
+            .when(clientFactory).createClient(
+                any(URI.class), 
+                any(String.class), 
+                any(String.class),
+                any(Integer.class),
+                any(String.class),
+                any(MessageHandler.class));
 
         // Start the task to initialize properties from config.properties
         task.start(props);


### PR DESCRIPTION
# 🔁 Add WebSocket Ping-Pong Support

This PR adds support for sending periodic WebSocket `ping` messages and handling incoming `pong` messages within the Kafka WebSocket source connector. This improves long-running stability and provides a mechanism to avoid timeouts.

## 🧩 Key Changes

### ✨ Enhancements:
- Added `WebSocketSourceConnectorConfig` class which offloads `ConfigDef` definition from `WebSocketSourceConnector` and provides validation on connector initialisation
- Adds periodic `ping` message sending using a scheduled task in the connector's WebSocket client
- Pings are sent at a fixed interval (default: 20 seconds)
- Handles incoming `pong` messages and logs acknowledgments
- Following connector configs were added:
  - `websocket.ping.message` - Optional ping message to send periodically to keep the WebSocket connection alive.
  - `websocket.ping.interval.ms` - Interval in milliseconds between each ping message.
  - `websocket.pong.pattern` - Regex pattern to detect pong responses in incoming WebSocket messages. If not provided, pong responses will be sent alongside other messages.

### 🔍 Test methods:
#### Unit tests:
- `WebSocketSourceTaskTest.testStart_WithAllValidConfigPassed ` verifies necessary ping configs are passed correctly
- `WebSocketSourceConnectorTest.testTaskConfigs_SingleTaskConfiguration`  same as above
- `DefaultWebSocketClientFactory.testCreateClient_WithValidParameters_ShouldReturnWebSocketClientWithUriAndPattern` verifies regex pattern is initialised properly from `websocket.pong.pattern`

#### Integration tests:
- `WebSocketConnectorIT.testWebSocketPing_ShouldSendAndIgnorePong` verfies ping message is sent correctly and pong messages are identified and ignored using the provided pattern while normal messages are sent to the Kafka topic. Uses Testcontainers and a fake local websocket server.

_Other tests were corrected as needed for this new connector configuration._

## 📦 Dependencies and Plugins:
_No changes._

## 📝 Notes:
> ⚠️ This is not protocol-level ping/pong handling. Application-level pings are sent vlike normal messages, but with a specific payload (same with app-level pongs when received).
> ⚠️ This feature does not include any closed connection handling when pongs are not received.

closes #11